### PR TITLE
Add `ocaml` dependency and license

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -6,9 +6,12 @@
 (source (github CraigFe/ocaml-rusage))
 (maintainers "Craig Ferguson <me@craigfe.io>")
 (authors "Zach Shipko")
+(license MIT)
 
 (package
  (name rusage)
  (synopsis "Bindings to the GETRUSAGE(2) syscall")
  (description "Bindings to the GETRUSAGE(2) syscall")
- (documentation https://CraigFe.github.io/ocaml-rusage/))
+ (documentation https://CraigFe.github.io/ocaml-rusage/)
+ (depends
+  ocaml))

--- a/rusage.opam
+++ b/rusage.opam
@@ -4,11 +4,13 @@ synopsis: "Bindings to the GETRUSAGE(2) syscall"
 description: "Bindings to the GETRUSAGE(2) syscall"
 maintainer: ["Craig Ferguson <me@craigfe.io>"]
 authors: ["Zach Shipko"]
+license: "MIT"
 homepage: "https://github.com/CraigFe/ocaml-rusage"
 doc: "https://CraigFe.github.io/ocaml-rusage/"
 bug-reports: "https://github.com/CraigFe/ocaml-rusage/issues"
 depends: [
   "dune" {>= "2.0"}
+  "ocaml"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
The `ocaml` dependency is necessary to build using Dune package management, as the package needs `ocaml` and can't depend on Dune depending on `ocaml`.

The `license` is useful to make the opam-linter happy. The license chosen is taken from the file in the repository.

I've submitted a PR to opam-repo to update this for released versions: https://github.com/ocaml/opam-repository/pull/26615